### PR TITLE
Add prefferedDelegate to CollectionViewWaterfallLayout

### DIFF
--- a/CollectionViewWaterfallLayout.swift
+++ b/CollectionViewWaterfallLayout.swift
@@ -79,6 +79,7 @@ public class CollectionViewWaterfallLayout: UICollectionViewLayout {
     }
     
     //MARK: Private Properties
+    private weak var prefferedDelegate: CollectionViewWaterfallLayoutDelegate?
     private weak var delegate: CollectionViewWaterfallLayoutDelegate?  {
         get {
             return collectionView?.delegate as? CollectionViewWaterfallLayoutDelegate

--- a/CollectionViewWaterfallLayout.swift
+++ b/CollectionViewWaterfallLayout.swift
@@ -92,6 +92,18 @@ public class CollectionViewWaterfallLayout: UICollectionViewLayout {
     private var footersAttribute = [Int: UICollectionViewLayoutAttributes]()
     private var unionRects = [CGRect]()
     
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    override public init() {
+        super.init()
+    }
+    
+    convenience public init(delegate: CollectionViewWaterfallLayoutDelegate) {
+        self.init()
+        prefferedDelegate = delegate
+    }
     
     //MARK: UICollectionViewLayout Methods
     override public func prepareLayout() {

--- a/CollectionViewWaterfallLayout.swift
+++ b/CollectionViewWaterfallLayout.swift
@@ -82,7 +82,8 @@ public class CollectionViewWaterfallLayout: UICollectionViewLayout {
     private weak var prefferedDelegate: CollectionViewWaterfallLayoutDelegate?
     private weak var delegate: CollectionViewWaterfallLayoutDelegate?  {
         get {
-            return collectionView?.delegate as? CollectionViewWaterfallLayoutDelegate
+            return prefferedDelegate ??
+                (collectionView?.delegate as? CollectionViewWaterfallLayoutDelegate)
         }
     }
     private var columnHeights = [Float]()


### PR DESCRIPTION
This changes are convenient for the case of using an custom object adapted UICollectionViewDelegate instead of collectionView's delegate.

This PR includes 2 changes:
- Add initializer to inject prefferedDelegate as it's argument
- Change delegate property to returns prefferedDelegate that the layout initialized with 
